### PR TITLE
Add a task to add missing taxonomy values

### DIFF
--- a/src/functionalTest/kotlin/com/neo4j/gradle/wordpress/WordPressPluginFunctionalTest.kt
+++ b/src/functionalTest/kotlin/com/neo4j/gradle/wordpress/WordPressPluginFunctionalTest.kt
@@ -66,7 +66,8 @@ title: Introduction to Neo4j 4.0
       // Run the task
       val result = runTask(projectDir)
 
-      val postJson = wordPressMockServer.postJson
+      assertEquals(wordPressMockServer.dataReceived.size, 1)
+      val postJson = wordPressMockServer.dataReceived.first()
       assertEquals(postJson["slug"] as String, "00-intro-neo4j-about")
       assertEquals(postJson["status"] as String, "private")
       assertEquals(postJson["title"] as String, "Introduction to Neo4j 4.0")
@@ -102,7 +103,8 @@ excerpt: Short introduction to Neo4j 4.0
       // Run the task
       val result = runTask(projectDir)
 
-      val postJson = wordPressMockServer.postJson
+      assertEquals(wordPressMockServer.dataReceived.size, 1)
+      val postJson = wordPressMockServer.dataReceived.first()
       assertEquals(postJson["slug"] as String, "00-intro-neo4j-about")
       assertEquals(postJson["status"] as String, "private")
       assertEquals(postJson["title"] as String, "Introduction to Neo4j 4.0")
@@ -139,7 +141,8 @@ featured_media: neo4j-nodes-bottom
       // Run the task
       val result = runTask(projectDir)
 
-      val postJson = wordPressMockServer.postJson
+      assertEquals(wordPressMockServer.dataReceived.size, 1)
+      val postJson = wordPressMockServer.dataReceived.first()
       assertEquals(postJson["slug"] as String, "00-intro-neo4j-about")
       assertEquals(postJson["status"] as String, "private")
       assertEquals(postJson["title"] as String, "Introduction to Neo4j 4.0")
@@ -176,7 +179,8 @@ featured_media: unexisting-media-slug
       // Run the task
       val result = runTask(projectDir)
 
-      val postJson = wordPressMockServer.postJson
+      assertEquals(wordPressMockServer.dataReceived.size, 1)
+      val postJson = wordPressMockServer.dataReceived.first()
       assertEquals(postJson["slug"] as String, "00-intro-neo4j-about")
       assertEquals(postJson["status"] as String, "private")
       assertEquals(postJson["title"] as String, "Introduction to Neo4j 4.0")
@@ -217,14 +221,15 @@ tags:
       // Run the task
       val result = runTask(projectDir)
 
-      val postJson = wordPressMockServer.postJson
+      assertEquals(wordPressMockServer.dataReceived.size, 1)
+      val postJson = wordPressMockServer.dataReceived.first()
       assertEquals(postJson["slug"] as String, "00-intro-neo4j-about")
       assertEquals(postJson["status"] as String, "private")
       assertEquals(postJson["title"] as String, "Introduction to Neo4j 4.0")
       assertEquals(postJson["content"] as String, postWithExcerpt.htmlContent)
       assertEquals(postJson["type"] as String, "post")
       assertNotNull(postJson["tags"])
-      val tags = postJson["tags"] as JsonArray<Number>
+      val tags = postJson["tags"] as JsonArray<*>
       assertTrue(tags.isNotEmpty())
       assertEquals(tags.size, 3)
       assertTrue(tags.contains(1))

--- a/src/functionalTest/kotlin/com/neo4j/gradle/wordpress/WordPressTaxonomySyncTaskFunctionalTest.kt
+++ b/src/functionalTest/kotlin/com/neo4j/gradle/wordpress/WordPressTaxonomySyncTaskFunctionalTest.kt
@@ -1,0 +1,196 @@
+package com.neo4j.gradle.wordpress
+
+import org.gradle.testkit.runner.BuildResult
+import org.gradle.testkit.runner.GradleRunner
+import org.gradle.testkit.runner.TaskOutcome
+import java.io.File
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class WordPressTaxonomySyncTaskFunctionalTest {
+  @Test
+  fun `run task with empty values`() {
+    // Setup the test build
+    val projectDir = File("build/syncTaxonomyFunctionalTest")
+    projectDir.mkdirs()
+    val emptyDir = File("build/syncTaxonomyFunctionalTest/empty")
+    emptyDir.mkdirs()
+    projectDir.resolve("settings.gradle").writeText("")
+    projectDir.resolve("build.gradle").writeText("""
+import com.neo4j.gradle.wordpress.WordPressTaxonomySyncTask
+
+plugins {
+  id('com.neo4j.gradle.wordpress.WordPressPlugin')
+}
+
+wordpress {
+  username = 'username'
+  password = 'password'
+  host = 'localhost'
+  scheme = 'http'
+}
+
+task wordPressTaxonomySync(type: WordPressTaxonomySyncTask) {
+  values = []
+  restBase = "neo4j_version"
+}
+""")
+    // Run the task
+    val result = runTask(projectDir)
+    val task = result.task(":wordPressTaxonomySync")
+    assertEquals(TaskOutcome.SUCCESS, task?.outcome)
+  }
+
+  @Test
+  fun `should create a new taxonomy value`() {
+    // Setup mock server to simulate WordPress
+    val wordPressMockServer = WordPressMockServer()
+    val server = wordPressMockServer.setup("")
+    try {
+      server.start()
+      // Setup the test build
+      val projectDir = File("build/syncTaxonomyFunctionalTest")
+      projectDir.mkdirs()
+      val dir = File("build/syncTaxonomyFunctionalTest/create")
+      dir.mkdirs()
+      projectDir.resolve("settings.gradle").writeText("")
+      projectDir.resolve("build.gradle").writeText("""
+import com.neo4j.gradle.wordpress.WordPressTaxonomySyncTask
+
+plugins {
+  id('com.neo4j.gradle.wordpress.WordPressPlugin')
+}
+
+wordpress {
+  username = 'username'
+  password = 'password'
+  port = ${server.port}
+  host = '${server.hostName}'
+  scheme = 'http'
+}
+
+task wordPressTaxonomySync(type: WordPressTaxonomySyncTask) {
+  values = ["1-9", "3-0", "2-3"]
+  restBase = "neo4j_version"
+}
+""")
+
+      // Run the task
+      val result = runTask(projectDir)
+
+      assertEquals(wordPressMockServer.dataReceived.size, 1)
+      val taxonomyJson = wordPressMockServer.dataReceived.first()
+      assertEquals(taxonomyJson["slug"] as String, "3-0")
+      assertEquals(taxonomyJson["name"] as String, "3-0")
+      val task = result.task(":wordPressTaxonomySync")
+      assertEquals(TaskOutcome.SUCCESS, task?.outcome)
+    } finally {
+      server.shutdown()
+    }
+  }
+
+  fun `should create multiple new taxonomy values`() {
+    // Setup mock server to simulate WordPress
+    val wordPressMockServer = WordPressMockServer()
+    val server = wordPressMockServer.setup("")
+    try {
+      server.start()
+      // Setup the test build
+      val projectDir = File("build/syncTaxonomyFunctionalTest")
+      projectDir.mkdirs()
+      val dir = File("build/syncTaxonomyFunctionalTest/create")
+      dir.mkdirs()
+      projectDir.resolve("settings.gradle").writeText("")
+      projectDir.resolve("build.gradle").writeText("""
+import com.neo4j.gradle.wordpress.WordPressTaxonomySyncTask
+
+plugins {
+  id('com.neo4j.gradle.wordpress.WordPressPlugin')
+}
+
+wordpress {
+  username = 'username'
+  password = 'password'
+  port = ${server.port}
+  host = '${server.hostName}'
+  scheme = 'http'
+}
+
+task wordPressTaxonomySync(type: WordPressTaxonomySyncTask) {
+  values = ["1-9", "3-0", "2-3", "4-1"]
+  restBase = "neo4j_version"
+}
+""")
+
+      // Run the task
+      val result = runTask(projectDir)
+
+      assertEquals(wordPressMockServer.dataReceived.size, 2)
+      val firstTaxonomyJson = wordPressMockServer.dataReceived[0]
+      assertEquals(firstTaxonomyJson["slug"] as String, "3-0")
+      assertEquals(firstTaxonomyJson["name"] as String, "3-0")
+      val secondTaxonomyJson = wordPressMockServer.dataReceived[1]
+      assertEquals(secondTaxonomyJson["slug"] as String, "4-1")
+      assertEquals(secondTaxonomyJson["name"] as String, "4-1")
+      val task = result.task(":wordPressTaxonomySync")
+      assertEquals(TaskOutcome.SUCCESS, task?.outcome)
+    } finally {
+      server.shutdown()
+    }
+  }
+
+  @Test
+  fun `should not create a new taxonomy value`() {
+    // Setup mock server to simulate WordPress
+    val wordPressMockServer = WordPressMockServer()
+    val server = wordPressMockServer.setup("")
+    try {
+      server.start()
+      // Setup the test build
+      val projectDir = File("build/syncTaxonomyFunctionalTest")
+      projectDir.mkdirs()
+      val dir = File("build/syncTaxonomyFunctionalTest/create")
+      dir.mkdirs()
+      projectDir.resolve("settings.gradle").writeText("")
+      projectDir.resolve("build.gradle").writeText("""
+import com.neo4j.gradle.wordpress.WordPressTaxonomySyncTask
+
+plugins {
+  id('com.neo4j.gradle.wordpress.WordPressPlugin')
+}
+
+wordpress {
+  username = 'username'
+  password = 'password'
+  port = ${server.port}
+  host = '${server.hostName}'
+  scheme = 'http'
+}
+
+task wordPressTaxonomySync(type: WordPressTaxonomySyncTask) {
+  values = ["1-9", "2-1", "2-3"]
+  restBase = "neo4j_version"
+}
+""")
+
+      // Run the task
+      val result = runTask(projectDir)
+
+      assertEquals(wordPressMockServer.dataReceived.size, 0)
+      val task = result.task(":wordPressTaxonomySync")
+      assertEquals(TaskOutcome.SUCCESS, task?.outcome)
+    } finally {
+      server.shutdown()
+    }
+  }
+
+  private fun runTask(projectDir: File): BuildResult {
+    val runner = GradleRunner.create()
+    runner.forwardOutput()
+    runner.withPluginClasspath()
+    runner.withArguments("wordPressTaxonomySync")
+    runner.withProjectDir(projectDir)
+    runner.withDebug(true)
+    return runner.build()
+  }
+}

--- a/src/functionalTest/resources/wordpress-rest-api/neo4j_version.json
+++ b/src/functionalTest/resources/wordpress-rest-api/neo4j_version.json
@@ -1,0 +1,47 @@
+[
+  {
+    "id": 22389,
+    "count": 0,
+    "description": "",
+    "link": "https:\/\/neo4j.com\/blog\/neo4j_version\/1-9\/",
+    "name": "1.9",
+    "slug": "1-9",
+    "taxonomy": "neo4j_version"
+  },
+  {
+    "id": 22385,
+    "count": 0,
+    "description": "",
+    "link": "https:\/\/neo4j.com\/blog\/neo4j_version\/2-0\/",
+    "name": "2.0",
+    "slug": "2-0",
+    "taxonomy": "neo4j_version"
+  },
+  {
+    "id": 22384,
+    "count": 0,
+    "description": "",
+    "link": "https:\/\/neo4j.com\/blog\/neo4j_version\/2-1\/",
+    "name": "2.1",
+    "slug": "2-1",
+    "taxonomy": "neo4j_version"
+  },
+  {
+    "id": 22382,
+    "count": 0,
+    "description": "",
+    "link": "https:\/\/neo4j.com\/blog\/neo4j_version\/2-2\/",
+    "name": "2.2",
+    "slug": "2-2",
+    "taxonomy": "neo4j_version"
+  },
+  {
+    "id": 22381,
+    "count": 0,
+    "description": "",
+    "link": "https:\/\/neo4j.com\/blog\/neo4j_version\/2-3\/",
+    "name": "2.3",
+    "slug": "2-3",
+    "taxonomy": "neo4j_version"
+  }
+]


### PR DESCRIPTION
#### Description

The task will create any missing taxonomy values for a given taxonomy `rest_base` (usually the `rest_base` is identical to the `slug` but not always).

#### Usage

```gradle
import com.neo4j.gradle.wordpress.WordPressTaxonomySyncTask

plugins {
  id('com.neo4j.gradle.wordpress.WordPressPlugin')
}

wordpress {
  username = 'username'
  password = 'password'
  host = 'localhost'
  scheme = 'http'
}

task wordPressTaxonomySync(type: WordPressTaxonomySyncTask) {
  values = ["1-9", "2-3", "3-0"]
  restBase = "neo4j_version"
}
```